### PR TITLE
Fix: Improve accordion collapse mechanism

### DIFF
--- a/index.html
+++ b/index.html
@@ -351,7 +351,7 @@
                         const isExpanded = button.getAttribute('aria-expanded') === 'true';
                         button.setAttribute('aria-expanded', !isExpanded);
                         const content = button.nextElementSibling;
-                        content.style.maxHeight = isExpanded ? null : content.scrollHeight + "px";
+                        content.style.maxHeight = isExpanded ? "0px" : content.scrollHeight + "px";
                     });
                 });
                 


### PR DESCRIPTION
I changed the JavaScript for the accordion component to use an explicit "0px" for `max-height` when collapsing an item. This replaces the use of `null` and provides a more robust way to ensure the style is applied for collapsing.

This change affects the Work-Related Deductions (D1-D10) section. Further manual testing is recommended to verify if this resolves any expansion issues.